### PR TITLE
feat: Add automated Garmin Connect sync script and fix date ranges

### DIFF
--- a/fitbit2garmin/commands.py
+++ b/fitbit2garmin/commands.py
@@ -5,7 +5,7 @@ import logging
 import pathlib
 
 from collections.abc import Callable, Coroutine
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from typing import Any
 
 import aiohttp
@@ -133,21 +133,28 @@ async def dump_weight(
     auth_file_path = cache_directory / auth_file_name
 
     # Fetch weight data month by month
-    date_pairs = [
-        (start, min(start + relativedelta(months=1, days=-1), end_date))
-        for start in map(
-            datetime.date,
-            rrule(MONTHLY, dtstart=start_date, until=end_date, bymonthday=1),
-        )
-    ]
+    date_pairs = []
+    current = start_date
+    while current <= end_date:
+        next_month = current + relativedelta(months=1)
+        end_of_current_month = next_month.replace(day=1) - timedelta(days=1)
+        chunk_end = min(end_of_current_month, end_date)
+        date_pairs.append((current, chunk_end))
+        current = chunk_end + timedelta(days=1)
+
     for i, (start_date_range, end_date_range) in enumerate(date_pairs):
         progress = f"[{i+1}/{len(date_pairs)}]"
         date_range = f"{start_date_range}-{end_date_range}"
         weight_file_path = weight_directory / f"weight.{date_range}.csv"
         weight_done_file_path = cache_directory / f".weight.{date_range}"
-        if weight_done_file_path.exists():
+        
+        # If the range ends today, we want to refresh it to get the latest weight.
+        is_today = end_date_range == date.today()
+        
+        if weight_done_file_path.exists() and not is_today:
             logging.info(f"{progress} Weight data for {date_range} already processed.")
             continue
+            
         logging.info(f"{progress} Fetching weight data for {date_range}.")
         get_weight_timeseries = run_aiohttp_fitbit_api_call(
             f"{progress} weight-{date_range}",
@@ -186,13 +193,15 @@ async def dump_activity(
     auth_file_path = cache_directory / auth_file_name
 
     # Fetch activity data month by month
-    date_pairs = [
-        (start, min(start + relativedelta(months=1, days=-1), end_date))
-        for start in map(
-            datetime.date,
-            rrule(MONTHLY, dtstart=start_date, until=end_date, bymonthday=1),
-        )
-    ]
+    date_pairs = []
+    current = start_date
+    while current <= end_date:
+        next_month = current + relativedelta(months=1)
+        end_of_current_month = next_month.replace(day=1) - timedelta(days=1)
+        chunk_end = min(end_of_current_month, end_date)
+        date_pairs.append((current, chunk_end))
+        current = chunk_end + timedelta(days=1)
+
     for i, (start_date_range, end_date_range) in enumerate(date_pairs):
         progress = f"[{i+1}/{len(date_pairs)}]"
         date_range = f"{start_date_range}-{end_date_range}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,13 @@ format = "python -m ufmt format fitbit2garmin"
 check-format = "python -m ufmt check fitbit2garmin"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 aiohttp = "^3.8.6"
 click = "^8.1.7"
 python-dateutil = "^2.8.2"
 asyncio-throttle = "^1.0.2"
 annotated-types = "^0.6.0"
+garminconnect = "^0.2.38"
 
 [build-system]
 requires = ["poetry-core"]

--- a/readme.md
+++ b/readme.md
@@ -114,6 +114,88 @@ import icon in the top right corner of the page (cloud with upward arrow icon).
 python -m pip uninstall fitbit2garmin
 ```
 
+## Sync to Garmin (Automated)
+
+If you wish to automate the upload of your weight data to Garmin Connect, you can use the provided `sync_garmin.py` script.
+
+1.  **Install the requirement:**
+    ```bash
+    pip install garminconnect
+    ```
+
+2.  **Run the script:**
+    ```bash
+    python sync_garmin.py
+    ```
+
+    You will be prompted for your Garmin Connect email and password.
+    
+    > **Note:** The script will first fetch the current day's weight data from Fitbit (using your existing `fitbit2garmin` authorization) and then attempt to upload all weight CSV files to Garmin.
+
+### Setting Environment Variables
+To automate the login process, you can set your Garmin credentials as environment variables so the script doesn't ask for them.
+
+**Temporary (for current session):**
+```bash
+export GARMIN_EMAIL="your.email@example.com"
+export GARMIN_PASSWORD="yourpassword"
+```
+
+**Permanent (add to .bashrc or .zshrc):**
+1. Open your profile file: `nano ~/.bashrc` (or `~/.zshrc` on Mac)
+2. Add the lines to the bottom:
+   ```bash
+   export GARMIN_EMAIL="your.email@example.com"
+   export GARMIN_PASSWORD="yourpassword"
+   ```
+3. Save and close (Ctrl+O, Enter, Ctrl+X).
+4. Reload the profile: `source ~/.bashrc`
+
+
+## Automated Daily/Hourly Sync (Cron)
+
+To run this script automatically on a server (e.g., Raspberry Pi, Debian VPS) without a display:
+
+1.  **Authenticate Locally First:**
+    Run the script on your local computer (where you have a browser) to complete the Fitbit OAuth2 login.
+    ```bash
+    python sync_garmin.py
+    ```
+    This creates a `.cache/.auth` file containing your access tokens.
+
+2.  **Transfer to Server:**
+    Copy the `.cache` directory (specifically `.cache/.auth`) from your local machine to the server, placing it in the same directory as `sync_garmin.py`.
+
+3.  **Install Dependencies on Server:**
+    Since cron runs with the system Python, it's easiest to install the libraries globally for your user (avoiding complex virtualenv paths):
+    ```bash
+    pip3 install garminconnect aiohttp click python-dateutil
+    ```
+
+4.  **Setup Cron Job:**
+    Edit your user's crontab (**do not use sudo**):
+    ```bash
+    crontab -e
+    ```
+    
+    *Example: Run every day at 6:00 AM*
+    ```bash
+    0 6 * * * export GARMIN_EMAIL="your@email.com"; export GARMIN_PASSWORD="yourpassword"; /usr/bin/python3 /path/to/fitbit2garmin/sync_garmin.py >> /path/to/fitbit2garmin/sync.log 2>&1
+    ```
+
+    *Example: Run every hour*
+    ```bash
+    0 * * * * export GARMIN_EMAIL="your@email.com"; export GARMIN_PASSWORD="yourpassword"; /usr/bin/python3 /path/to/fitbit2garmin/sync_garmin.py >> /path/to/fitbit2garmin/sync.log 2>&1
+    ```
+
+    *Example: Smart Schedule (Every 15 mins between 6 AM and 9 AM)*
+    ```bash
+    */15 6-9 * * * export GARMIN_EMAIL="your@email.com"; export GARMIN_PASSWORD="yourpassword"; /usr/bin/python3 /path/to/fitbit2garmin/sync_garmin.py >> /path/to/fitbit2garmin/sync.log 2>&1
+    ```
+    
+    > **Note:** `/path/to/fitbit2garmin/sync.log` is a file where the script's output (success messages or errors) will be written. This helps you debug if something goes wrong. You can place this file anywhere you have write access.
+
+
 ## Disclaimer
 
 This product is not sold or affiliated in any way with Fitbit or Garmin, and

--- a/sync_garmin.py
+++ b/sync_garmin.py
@@ -165,6 +165,30 @@ def upload_activities_to_garmin(garmin):
         except Exception as e:
             log(f"Failed to upload {file_path}: {e}")
 
+import time
+
+def cleanup_old_files():
+    """
+    Deletes files in data and activity directories older than 3 days.
+    """
+    cutoff = time.time() - (3 * 86400) # 3 days in seconds
+    
+    for directory in [DATA_DIR, ACTIVITY_DIR]:
+        if not directory.exists():
+            continue
+            
+        for file_path in directory.iterdir():
+            if file_path.is_file():
+                try:
+                    stat = file_path.stat()
+                    if stat.st_mtime < cutoff:
+                        # Double check it's a data file we generated
+                        if file_path.suffix in ['.csv', '.tcx', '.jsonl']:
+                            log(f"Deleting old file: {file_path}")
+                            file_path.unlink()
+                except Exception as e:
+                    log(f"Error checking/deleting {file_path}: {e}")
+
 def main():
     parser = argparse.ArgumentParser(description="Sync Fitbit data to Garmin Connect.")
     parser.add_argument("--weight", action="store_true", default=True, help="Sync weight data (default)")
@@ -213,6 +237,9 @@ def main():
             log(f"Error logging in: {err}")
     else:
         log("Credentials not provided. Skipping upload.")
+        
+    # 3. Cleanup
+    cleanup_old_files()
 
 if __name__ == "__main__":
     main()

--- a/sync_garmin.py
+++ b/sync_garmin.py
@@ -6,6 +6,7 @@ import pathlib
 import sys
 import csv
 import datetime
+import argparse
 from datetime import date, timedelta
 from getpass import getpass
 
@@ -28,9 +29,15 @@ except ImportError:
     from fitbit2garmin import commands
 
 CACHE_DIR = BASE_DIR / ".cache"
-DATA_DIR = BASE_DIR / "f2g"
+# Check if .env/.auth exists (used by fitbit2garmin dump-weight default)
+# If so, prefer it to ensure we use the active token.
+if (BASE_DIR / ".env" / ".auth").exists():
+    CACHE_DIR = BASE_DIR / ".env"
 
-async def fetch_fitbit_data():
+DATA_DIR = BASE_DIR / "f2g"
+ACTIVITY_DIR = DATA_DIR / "activities"
+
+async def fetch_fitbit_weight():
     """
     Fetches the current day's weight data from Fitbit.
     """
@@ -49,21 +56,33 @@ async def fetch_fitbit_data():
         start_date,
         end_date
     )
-    print("Fitbit download complete.")
+    print("Fitbit weight download complete.")
 
-def upload_to_garmin(email, password):
+async def fetch_fitbit_activities():
+    """
+    Fetches the current day's activity data (TCX) from Fitbit.
+    """
+    end_date = date.today()
+    start_date = end_date
+    
+    print(f"Fetching Fitbit activity data (TCX) for {start_date}...")
+    
+    # Ensure directories exist
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    ACTIVITY_DIR.mkdir(parents=True, exist_ok=True)
+    
+    await commands.dump_activity_tcx(
+        CACHE_DIR,
+        ACTIVITY_DIR,
+        start_date,
+        end_date
+    )
+    print("Fitbit activity download complete.")
+
+def upload_weight_to_garmin(garmin):
     """
     Uploads weight data from CSV files to Garmin Connect.
     """
-    print("Logging into Garmin Connect...")
-    try:
-        garmin = Garmin(email, password)
-        garmin.login()
-        print("Login successful.")
-    except Exception as err:
-        print(f"Error logging in: {err}")
-        return
-
     # Find all weight files
     files = sorted(glob.glob(str(DATA_DIR / "weight.*.csv")))
     
@@ -121,18 +140,51 @@ def upload_to_garmin(email, password):
         except Exception as e:
             print(f"Failed to read {file_path}: {e}")
 
+def upload_activities_to_garmin(garmin):
+    """
+    Uploads TCX activity files to Garmin Connect.
+    """
+    # Find all TCX files
+    files = sorted(glob.glob(str(ACTIVITY_DIR / "*.tcx")))
+    
+    if not files:
+        print("No activity (TCX) files found to upload.")
+        return
+
+    print(f"Found {len(files)} activity files.")
+    
+    for file_path in files:
+        print(f"Uploading activity {file_path}...")
+        try:
+            # upload_activity is the correct method for TCX/FIT/GPX files
+            upload_status = garmin.upload_activity(file_path)
+            print(f"Upload result: {upload_status}")
+        except Exception as e:
+            print(f"Failed to upload {file_path}: {e}")
+
 def main():
+    parser = argparse.ArgumentParser(description="Sync Fitbit data to Garmin Connect.")
+    parser.add_argument("--weight", action="store_true", default=True, help="Sync weight data (default)")
+    parser.add_argument("--activity", action="store_true", help="Sync activity data (TCX)")
+    parser.add_argument("--no-weight", action="store_false", dest="weight", help="Skip weight sync")
+    args = parser.parse_args()
+
     # 1. Fetch Data from Fitbit
-    # Run async loop for fitbit fetch
     try:
-        asyncio.run(fetch_fitbit_data())
+        if args.weight:
+            asyncio.run(fetch_fitbit_weight())
+        if args.activity:
+            asyncio.run(fetch_fitbit_activities())
     except Exception as e:
         print(f"Error fetching Fitbit data: {e}")
-        # Continue to upload phase? Or exit?
-        # If fetch fails (e.g. auth), maybe we still want to upload existing files.
         print("Proceeding to upload phase with existing files...")
 
     # 2. Upload to Garmin
+    # Only login if we have something to upload or just downloaded something
+    if not (args.weight or args.activity):
+        print("Nothing to sync. Use --weight or --activity.")
+        return
+
     email = os.getenv("GARMIN_EMAIL")
     password = os.getenv("GARMIN_PASSWORD")
     
@@ -143,7 +195,19 @@ def main():
         password = getpass("Garmin Password: ")
 
     if email and password:
-        upload_to_garmin(email, password)
+        print("Logging into Garmin Connect...")
+        try:
+            garmin = Garmin(email, password)
+            garmin.login()
+            print("Login successful.")
+            
+            if args.weight:
+                upload_weight_to_garmin(garmin)
+            if args.activity:
+                upload_activities_to_garmin(garmin)
+                
+        except Exception as err:
+            print(f"Error logging in: {err}")
     else:
         print("Credentials not provided. Skipping upload.")
 

--- a/sync_garmin.py
+++ b/sync_garmin.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+import asyncio
+import glob
+import os
+import pathlib
+import sys
+import csv
+import datetime
+from datetime import date, timedelta
+from getpass import getpass
+
+try:
+    from garminconnect import Garmin
+except ImportError as e:
+    print(f"Error: The 'garminconnect' library is required. Details: {e}")
+    print("Please install it using: pip install garminconnect")
+    sys.exit(1)
+
+# Determine the directory where this script is located
+BASE_DIR = pathlib.Path(__file__).parent.resolve()
+
+# Import fitbit2garmin commands
+try:
+    from fitbit2garmin import commands
+except ImportError:
+    # If running from root without package installation, add the script's directory to path
+    sys.path.append(str(BASE_DIR))
+    from fitbit2garmin import commands
+
+CACHE_DIR = BASE_DIR / ".cache"
+DATA_DIR = BASE_DIR / "f2g"
+
+async def fetch_fitbit_data():
+    """
+    Fetches the current day's weight data from Fitbit.
+    """
+    end_date = date.today()
+    start_date = end_date
+    
+    print(f"Fetching Fitbit weight data for {start_date}...")
+    
+    # Ensure directories exist
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    
+    await commands.dump_weight(
+        CACHE_DIR,
+        DATA_DIR,
+        start_date,
+        end_date
+    )
+    print("Fitbit download complete.")
+
+def upload_to_garmin(email, password):
+    """
+    Uploads weight data from CSV files to Garmin Connect.
+    """
+    print("Logging into Garmin Connect...")
+    try:
+        garmin = Garmin(email, password)
+        garmin.login()
+        print("Login successful.")
+    except Exception as err:
+        print(f"Error logging in: {err}")
+        return
+
+    # Find all weight files
+    files = sorted(glob.glob(str(DATA_DIR / "weight.*.csv")))
+    
+    if not files:
+        print("No weight files found to upload.")
+        return
+
+    print(f"Found {len(files)} weight files.")
+    
+    for file_path in files:
+        print(f"Processing {file_path}...")
+        try:
+            with open(file_path, 'r') as csvfile:
+                # The file might start with a "Body" line, so we check/skip it
+                first_line = csvfile.readline()
+                if not first_line.strip().startswith("Body"):
+                    csvfile.seek(0)
+                
+                reader = csv.DictReader(csvfile)
+                # Check headers
+                if not reader.fieldnames or not {'Date', 'Weight'}.issubset(reader.fieldnames):
+                     print(f"Skipping {file_path}: Missing Date or Weight columns. Found: {reader.fieldnames}")
+                     continue
+                     
+                for row in reader:
+                    date_str = row['Date']
+                    weight = float(row['Weight'])
+                    bmi = float(row.get('BMI', 0))
+                    fat = float(row.get('Fat', 0))
+                    
+                    try:
+                        if hasattr(garmin, 'add_body_composition'):
+                           # Construct timestamp for 08:00 AM
+                           dt = datetime.datetime.strptime(date_str, "%Y-%m-%d")
+                           dt = dt.replace(hour=8, minute=0)
+                           timestamp = dt.isoformat()
+                           
+                           garmin.add_body_composition(
+                               timestamp=timestamp,
+                               weight=weight,
+                               percent_fat=fat if fat > 0 else None,
+                           )
+                           print(f"Uploaded weight for {date_str}: {weight}kg, {fat}% fat")
+                           
+                        elif hasattr(garmin, 'add_weigh_in'):
+                             garmin.add_weigh_in(weight, 'kg', date_str)
+                             print(f"Uploaded weight (basic) for {date_str}: {weight}kg")
+                        else:
+                             print("Error: Could not find a suitable method to upload weight in 'garminconnect'.")
+                             return
+
+                    except Exception as e:
+                        print(f"Failed to upload entry for {date_str}: {e}")
+
+        except Exception as e:
+            print(f"Failed to read {file_path}: {e}")
+
+def main():
+    # 1. Fetch Data from Fitbit
+    # Run async loop for fitbit fetch
+    try:
+        asyncio.run(fetch_fitbit_data())
+    except Exception as e:
+        print(f"Error fetching Fitbit data: {e}")
+        # Continue to upload phase? Or exit?
+        # If fetch fails (e.g. auth), maybe we still want to upload existing files.
+        print("Proceeding to upload phase with existing files...")
+
+    # 2. Upload to Garmin
+    email = os.getenv("GARMIN_EMAIL")
+    password = os.getenv("GARMIN_PASSWORD")
+    
+    if not email:
+        print("\nPlease provide Garmin credentials.")
+        email = input("Garmin Email: ")
+    if not password:
+        password = getpass("Garmin Password: ")
+
+    if email and password:
+        upload_to_garmin(email, password)
+    else:
+        print("Credentials not provided. Skipping upload.")
+
+if __name__ == "__main__":
+    main()

--- a/sync_garmin.py
+++ b/sync_garmin.py
@@ -37,6 +37,9 @@ if (BASE_DIR / ".env" / ".auth").exists():
 DATA_DIR = BASE_DIR / "f2g"
 ACTIVITY_DIR = DATA_DIR / "activities"
 
+def log(msg):
+    print(f"[{datetime.datetime.now()}] {msg}")
+
 async def fetch_fitbit_weight():
     """
     Fetches the current day's weight data from Fitbit.
@@ -44,7 +47,7 @@ async def fetch_fitbit_weight():
     end_date = date.today()
     start_date = end_date
     
-    print(f"Fetching Fitbit weight data for {start_date}...")
+    log(f"Fetching Fitbit weight data for {start_date}...")
     
     # Ensure directories exist
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
@@ -56,7 +59,7 @@ async def fetch_fitbit_weight():
         start_date,
         end_date
     )
-    print("Fitbit weight download complete.")
+    log("Fitbit weight download complete.")
 
 async def fetch_fitbit_activities():
     """
@@ -65,7 +68,7 @@ async def fetch_fitbit_activities():
     end_date = date.today()
     start_date = end_date
     
-    print(f"Fetching Fitbit activity data (TCX) for {start_date}...")
+    log(f"Fetching Fitbit activity data (TCX) for {start_date}...")
     
     # Ensure directories exist
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
@@ -77,7 +80,7 @@ async def fetch_fitbit_activities():
         start_date,
         end_date
     )
-    print("Fitbit activity download complete.")
+    log("Fitbit activity download complete.")
 
 def upload_weight_to_garmin(garmin):
     """
@@ -87,13 +90,13 @@ def upload_weight_to_garmin(garmin):
     files = sorted(glob.glob(str(DATA_DIR / "weight.*.csv")))
     
     if not files:
-        print("No weight files found to upload.")
+        log("No weight files found to upload.")
         return
 
-    print(f"Found {len(files)} weight files.")
+    log(f"Found {len(files)} weight files.")
     
     for file_path in files:
-        print(f"Processing {file_path}...")
+        log(f"Processing {file_path}...")
         try:
             with open(file_path, 'r') as csvfile:
                 # The file might start with a "Body" line, so we check/skip it
@@ -104,7 +107,7 @@ def upload_weight_to_garmin(garmin):
                 reader = csv.DictReader(csvfile)
                 # Check headers
                 if not reader.fieldnames or not {'Date', 'Weight'}.issubset(reader.fieldnames):
-                     print(f"Skipping {file_path}: Missing Date or Weight columns. Found: {reader.fieldnames}")
+                     log(f"Skipping {file_path}: Missing Date or Weight columns. Found: {reader.fieldnames}")
                      continue
                      
                 for row in reader:
@@ -125,20 +128,20 @@ def upload_weight_to_garmin(garmin):
                                weight=weight,
                                percent_fat=fat if fat > 0 else None,
                            )
-                           print(f"Uploaded weight for {date_str}: {weight}kg, {fat}% fat")
+                           log(f"Uploaded weight for {date_str}: {weight}kg, {fat}% fat")
                            
                         elif hasattr(garmin, 'add_weigh_in'):
                              garmin.add_weigh_in(weight, 'kg', date_str)
-                             print(f"Uploaded weight (basic) for {date_str}: {weight}kg")
+                             log(f"Uploaded weight (basic) for {date_str}: {weight}kg")
                         else:
-                             print("Error: Could not find a suitable method to upload weight in 'garminconnect'.")
+                             log("Error: Could not find a suitable method to upload weight in 'garminconnect'.")
                              return
 
                     except Exception as e:
-                        print(f"Failed to upload entry for {date_str}: {e}")
+                        log(f"Failed to upload entry for {date_str}: {e}")
 
         except Exception as e:
-            print(f"Failed to read {file_path}: {e}")
+            log(f"Failed to read {file_path}: {e}")
 
 def upload_activities_to_garmin(garmin):
     """
@@ -148,19 +151,19 @@ def upload_activities_to_garmin(garmin):
     files = sorted(glob.glob(str(ACTIVITY_DIR / "*.tcx")))
     
     if not files:
-        print("No activity (TCX) files found to upload.")
+        log("No activity (TCX) files found to upload.")
         return
 
-    print(f"Found {len(files)} activity files.")
+    log(f"Found {len(files)} activity files.")
     
     for file_path in files:
-        print(f"Uploading activity {file_path}...")
+        log(f"Uploading activity {file_path}...")
         try:
             # upload_activity is the correct method for TCX/FIT/GPX files
             upload_status = garmin.upload_activity(file_path)
-            print(f"Upload result: {upload_status}")
+            log(f"Upload result: {upload_status}")
         except Exception as e:
-            print(f"Failed to upload {file_path}: {e}")
+            log(f"Failed to upload {file_path}: {e}")
 
 def main():
     parser = argparse.ArgumentParser(description="Sync Fitbit data to Garmin Connect.")
@@ -176,13 +179,13 @@ def main():
         if args.activity:
             asyncio.run(fetch_fitbit_activities())
     except Exception as e:
-        print(f"Error fetching Fitbit data: {e}")
-        print("Proceeding to upload phase with existing files...")
+        log(f"Error fetching Fitbit data: {e}")
+        log("Proceeding to upload phase with existing files...")
 
     # 2. Upload to Garmin
     # Only login if we have something to upload or just downloaded something
     if not (args.weight or args.activity):
-        print("Nothing to sync. Use --weight or --activity.")
+        log("Nothing to sync. Use --weight or --activity.")
         return
 
     email = os.getenv("GARMIN_EMAIL")
@@ -195,11 +198,11 @@ def main():
         password = getpass("Garmin Password: ")
 
     if email and password:
-        print("Logging into Garmin Connect...")
+        log("Logging into Garmin Connect...")
         try:
             garmin = Garmin(email, password)
             garmin.login()
-            print("Login successful.")
+            log("Login successful.")
             
             if args.weight:
                 upload_weight_to_garmin(garmin)
@@ -207,9 +210,9 @@ def main():
                 upload_activities_to_garmin(garmin)
                 
         except Exception as err:
-            print(f"Error logging in: {err}")
+            log(f"Error logging in: {err}")
     else:
-        print("Credentials not provided. Skipping upload.")
+        log("Credentials not provided. Skipping upload.")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Hi Simone,

happy new year, and thanks for this great tool! I've been using it to migrate my weight data, but I really wanted a "set and forget" solution to keep Garmin updated automatically whenever I step on the scale. It should handle activity data as well with relatively minor changes I think, but I do not use fitbit for anything other than weight anymore, so I did not implement this.

Fair warning: the code for this PR was mostly generated with gemini. I checked it over, and it runs successfully on my server as a cron job, but if you do not accept this no worries.

I'm submitting a few changes to enable that workflow:

## Automated Sync Script (sync_garmin.py): 
I added a script that fetches today's weight data and immediately uploads it to Garmin Connect (using the garminconnect library). It works great with cron on a headless server (like a Raspberry Pi).

## Bug Fix for Daily Downloads: 
I noticed that dump-all would sometimes skip single-day ranges (like just asking for "today"). I updated the loop logic in [commands.py](code-assist-path:/Users/boris/Documents/python%20programs/fitbit2garmin/fitbit2garmin/commands.py) to fix this so it reliably fetches the latest data.

##Documentation: 
Added a section to the README explaining how to set up this automation.
I also bumped the Python version to 3.10+ to support the garminconnect library.

I hope you find this useful enough to accept the PR, 